### PR TITLE
Instance state has moved from field $5 to field $6

### DIFF
--- a/cookbooks/rightscale_services_tools/templates/default/nat-monitor.erb
+++ b/cookbooks/rightscale_services_tools/templates/default/nat-monitor.erb
@@ -59,7 +59,7 @@ while [ . ]; do
         ROUTE_HEALTHY=1
       fi
       # Check NAT state to see if we should stop it or start it again
-      NAT_STATE=`/home/ec2/bin/ec2-describe-instances $NAT_ID -U $EC2_URL | grep INSTANCE | awk '{print $5;}'`
+      NAT_STATE=`/home/ec2/bin/ec2-describe-instances $NAT_ID -U $EC2_URL | grep INSTANCE | awk '{print $6;}'`
       if [ "$NAT_STATE" == "stopped" ]; then
         echo `date` "-- Other NAT instance stopped, starting it back up"
         /home/ec2/bin/ec2-start-instances $NAT_ID -U $EC2_URL


### PR DESCRIPTION
`ec2-describe-instances` has changed its instance state output from field 5 to field 6, thus NAT_STATE needs to be updated.

Example:

``` bash
$ ec2-describe-instances | grep INST | awk '{print $5}'
domU-12-31-39-07-D0-C6.compute-1.internal
domU-12-31-39-0E-E0-72.compute-1.internal
ip-10-12-85-167.ec2.internal
ip-10-62-75-27.ec2.internal
ip-10-80-150-207.ec2.internal
ip-10-60-10-141.ec2.internal
ip-10-238-226-152.ec2.internal

$ ec2-describe-instances | grep INST | awk '{print $6}'
running
running
running
running
running
running
running
```
